### PR TITLE
fix: render xml

### DIFF
--- a/src/cli/utils/assemble.ts
+++ b/src/cli/utils/assemble.ts
@@ -13,6 +13,7 @@ interface LocalFiles {
   template_path?: string | null
   slot_path?: string | null
   mime_type?: string
+  extension?: string
 }
 
 /**
@@ -68,6 +69,7 @@ async function readLocalFiles(dir: string = '.'): Promise<LocalFiles> {
     result.template_path = settings.template_path
     result.slot_path = settings.slot_path
     result.mime_type = settings.mime_type
+    result.extension = settings.extension
   } catch {}
 
   return result
@@ -166,8 +168,10 @@ export async function assemble(
   const mimeType = files.mime_type || 'text/html; charset=UTF-8'
 
   // Normalize extension: .md, .html, and .eta all become .html since they render to HTML
+  // Settings extension takes priority when explicitly set
   const actualExtension = extname(contentFile).toLowerCase()
-  const extension = ['.md', '.html', '.eta'].includes(actualExtension) ? '.html' : actualExtension
+  const derivedExtension = ['.md', '.html', '.eta'].includes(actualExtension) ? '.html' : actualExtension
+  const extension = files.extension || derivedExtension
 
   // Create a minimal RenderDocument structure
   const now = new Date()

--- a/test/render/index.test.ts
+++ b/test/render/index.test.ts
@@ -2856,3 +2856,52 @@ test('render() with template: both style and script are injected', async () => {
   const headIdx = result.html.indexOf('<head>')
   assert.ok(styleIdx > headIdx, 'Style should be inside head')
 })
+
+// Extension .xml should not inject base, style, or script
+test('render() with .xml extension: no base, style, or script injected', async () => {
+  const doc = makeDoc({
+    content: '<?xml version="1.0"?><rss><channel><title>Test</title></channel></rss>',
+    extension: '.xml',
+    mime_type: 'application/rss+xml',
+    style: '/* Custom styles */',
+    script: '// Client JS',
+  })
+  const result = await renderDoc(doc)
+  assert.ok(!result.html.includes('<base'), 'No base tag should be injected for .xml')
+  assert.ok(!result.html.includes('<style>'), 'No style tag should be injected for .xml')
+  assert.ok(!result.html.includes('<script>'), 'No script tag should be injected for .xml')
+  assert.ok(result.html.includes('<?xml version="1.0"?>'), 'XML content should be preserved')
+})
+
+test('render() with .xml extension and template: no base, style, or script injected', async () => {
+  const doc = makeDoc({
+    content: '<?xml version="1.0"?><rss><channel><title>Test</title></channel></rss>',
+    extension: '.xml',
+    mime_type: 'application/rss+xml',
+    style: '/* Custom styles */',
+    script: '// Client JS',
+    template: makeDoc({
+      content: '<%= slot.html %>',
+      style: '.template { margin: 0; }',
+      script: 'console.log("template")',
+    }),
+  })
+  const result = await renderDoc(doc)
+  assert.ok(!result.html.includes('<base'), 'No base tag should be injected for .xml with template')
+  assert.ok(!result.html.includes('<style>'), 'No style tag should be injected for .xml with template')
+  assert.ok(!result.html.includes('<script>'), 'No script tag should be injected for .xml with template')
+})
+
+// Extension .html should inject base, style, and script
+test('render() with .html extension: base, style, and script are injected', async () => {
+  const doc = makeDoc({
+    content: '<p>Hello</p>',
+    extension: '.html',
+    style: 'body { margin: 0; }',
+    script: 'console.log("hello")',
+  })
+  const result = await renderDoc(doc)
+  assert.ok(result.html.includes('<base'), 'Base tag should be injected for .html')
+  assert.ok(result.html.includes('<style>body { margin: 0; }</style>'), 'Style should be injected for .html')
+  assert.ok(result.html.includes('<script>console.log("hello")</script>'), 'Script should be injected for .html')
+})


### PR DESCRIPTION
currently script / style / base are injected even if the extension resolve is not .html, this fixes that so that it wont do that if the extension is not .html (the default) this still should download xml with eta as .eta 