### PR TITLE
feat: `excludeTemplates` by default from `fn.getPages`

### DIFF
--- a/README.md
+++ b/README.md
@@ -643,14 +643,15 @@ The returned object contains the same properties available as ETA variables: `ti
 
 Returns an array of fully rendered page objects. Each item has the same shape as `fn.getPage()`.
 
-| Option           | Type                                                      | Description                                   |
-| ---------------- | --------------------------------------------------------- | --------------------------------------------- |
-| `sortBy`         | `'created_at'` \| `'updated_at'` \| `'title'` \| `'path'` | Sort field                                    |
-| `sortOrder`      | `'asc'` \| `'desc'`                                       | Sort direction                                |
-| `published`      | `boolean`                                                 | Filter by published status                    |
-| `limit`          | `number`                                                  | Max results                                   |
-| `offset`         | `number`                                                  | Skip results                                  |
-| `startsWithPath` | `string`                                                  | Filter pages by path prefix (e.g., `"/blog"`) |
+| Option             | Type                                                      | Description                                                          |
+| ------------------ | --------------------------------------------------------- | -------------------------------------------------------------------- |
+| `sortBy`           | `'created_at'` \| `'updated_at'` \| `'title'` \| `'path'` | Sort field                                                           |
+| `sortOrder`        | `'asc'` \| `'desc'`                                       | Sort direction                                                       |
+| `published`        | `boolean`                                                 | Filter by published status                                           |
+| `limit`            | `number`                                                  | Max results                                                          |
+| `offset`           | `number`                                                  | Skip results                                                         |
+| `startsWithPath`   | `string`                                                  | Filter pages by path prefix (e.g., `"/blog"`)                        |
+| `excludeTemplates` | `boolean`                                                 | Exclude pages used as a template by any other page (default: `true`) |
 
 ```javascript
 const posts = await fn.getPages({

--- a/pages/skywriter/content.md
+++ b/pages/skywriter/content.md
@@ -646,14 +646,15 @@ The returned object contains the same properties available as ETA variables: `ti
 
 Returns an array of fully rendered page objects. Each item has the same shape as `fn.getPage()`.
 
-| Option           | Type                                                      | Description                                   |
-| ---------------- | --------------------------------------------------------- | --------------------------------------------- |
-| `sortBy`         | `'created_at'` \| `'updated_at'` \| `'title'` \| `'path'` | Sort field                                    |
-| `sortOrder`      | `'asc'` \| `'desc'`                                       | Sort direction                                |
-| `published`      | `boolean`                                                 | Filter by published status                    |
-| `limit`          | `number`                                                  | Max results                                   |
-| `offset`         | `number`                                                  | Skip results                                  |
-| `startsWithPath` | `string`                                                  | Filter pages by path prefix (e.g., `"/blog"`) |
+| Option             | Type                                                      | Description                                                          |
+| ------------------ | --------------------------------------------------------- | -------------------------------------------------------------------- |
+| `sortBy`           | `'created_at'` \| `'updated_at'` \| `'title'` \| `'path'` | Sort field                                                           |
+| `sortOrder`        | `'asc'` \| `'desc'`                                       | Sort direction                                                       |
+| `published`        | `boolean`                                                 | Filter by published status                                           |
+| `limit`            | `number`                                                  | Max results                                                          |
+| `offset`           | `number`                                                  | Skip results                                                         |
+| `startsWithPath`   | `string`                                                  | Filter pages by path prefix (e.g., `"/blog"`)                        |
+| `excludeTemplates` | `boolean`                                                 | Exclude pages used as a template by any other page (default: `true`) |
 
 ```javascript
 const posts = await fn.getPages({

--- a/src/operations/getDualDocuments.ts
+++ b/src/operations/getDualDocuments.ts
@@ -33,6 +33,7 @@ export const getDualDocuments: DbOperation<[DocumentManyQuery?], DualDocument[]>
     limit,
     offset = 0,
     startsWithPath,
+    excludeTemplates = false,
   } = options
 
   try {
@@ -53,6 +54,10 @@ export const getDualDocuments: DbOperation<[DocumentManyQuery?], DualDocument[]>
       whereClauses.push(`r.path LIKE $${paramIndex}`)
       queryParams.push(`${startsWithPath}%`)
       paramIndex++
+    }
+
+    if (excludeTemplates) {
+      whereClauses.push(`d.id NOT IN (SELECT DISTINCT template_id FROM document_records WHERE template_id IS NOT NULL)`)
     }
 
     const whereClause = whereClauses.length > 0 ? `WHERE ${whereClauses.join(' AND ')}` : ''

--- a/src/operations/getPages.ts
+++ b/src/operations/getPages.ts
@@ -23,6 +23,7 @@ export const getPages: DbOperation<
     includeSlot: true,
     includeTemplate: true,
     draft: false,
+    excludeTemplates: true,
     ...options,
   })
 

--- a/src/operations/types.ts
+++ b/src/operations/types.ts
@@ -180,6 +180,8 @@ export interface DocumentManyQuery {
   limit?: number
   offset?: number
   startsWithPath?: string
+  /** Exclude documents that are used as a template by any other document (default: false, but getPages defaults to true) */
+  excludeTemplates?: boolean
 }
 
 export interface SearchOptions {

--- a/test/fn/functionContext.test.ts
+++ b/test/fn/functionContext.test.ts
@@ -32,6 +32,9 @@ describe('functionContext', () => {
       `/test-function-context-1-${testId}`,
       `/test-function-context-2-${testId}`,
       `/test-function-context-3-${testId}`,
+      `/test-fc-template-${testId}`,
+      `/test-fc-page-${testId}`,
+      `/test-fc-regular-${testId}`,
     ]
     for (const path of paths) {
       try {
@@ -279,6 +282,70 @@ describe('functionContext', () => {
 
       assert.ok(Array.isArray(result), 'Should return an array')
       assert.equal(result.length, 1, 'Should return exactly 1 document due to limit')
+    })
+
+    it('should exclude template documents by default', async () => {
+      // Create a template document
+      const templateResult = await upsert(client, {
+        path: `/test-fc-template-${testId}`,
+        title: 'Template',
+        content: '# Template',
+        published: true,
+      })
+
+      // Create a page that uses the template (via template_id on its record)
+      await upsert(client, {
+        path: `/test-fc-page-${testId}`,
+        title: 'Page',
+        content: '# Page',
+        published: true,
+        template_id: templateResult.id,
+      })
+
+      // Create a regular page (no template usage)
+      await upsert(client, {
+        path: `/test-fc-regular-${testId}`,
+        title: 'Regular',
+        content: '# Regular',
+        published: true,
+      })
+
+      const mockDoc = {path: '/some-path'} as unknown as {path: string}
+      const ctx = functionContext(client, mockDoc)
+
+      // Default call should exclude the template document (3 docs created, template excluded = 2 results)
+      const result = await ctx.getPages({startsWithPath: `/test-fc-`})
+      assert.equal(result.length, 2, 'Should return 2 documents (template excluded by default)')
+
+      // With excludeTemplates=false, all 3 documents should be returned
+      const resultAll = await ctx.getPages({startsWithPath: `/test-fc-`, excludeTemplates: false})
+      assert.equal(resultAll.length, 3, 'Should return 3 documents when excludeTemplates is false')
+    })
+
+    it('should include template documents when excludeTemplates is false', async () => {
+      // Create a template document
+      const templateResult = await upsert(client, {
+        path: `/test-fc-template-${testId}`,
+        title: 'Template',
+        content: '# Template',
+        published: true,
+      })
+
+      // Create a page that uses the template
+      await upsert(client, {
+        path: `/test-fc-page-${testId}`,
+        title: 'Page',
+        content: '# Page',
+        published: true,
+        template_id: templateResult.id,
+      })
+
+      const mockDoc = {path: '/some-path'} as unknown as {path: string}
+      const ctx = functionContext(client, mockDoc)
+
+      // Explicitly opt out of excluding templates — both documents should be returned
+      const result = await ctx.getPages({startsWithPath: `/test-fc-`, excludeTemplates: false})
+      assert.equal(result.length, 2, 'Should return 2 documents when excludeTemplates is false')
     })
   })
 


### PR DESCRIPTION
`fn.getPages` is much more useful if templates doesn't aren't included as they're not real documents you'd want to show in rss, or a list of pages, this is technically a "breaking" change but we don't even have 1 star on this yet so 🙃 

addes `excludeTemplates` true by default to fn.getPages