### PR TITLE
fix: FileCredentialStore adds --auth-store

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,7 +247,6 @@ skywriter <command>
 
 | Option                | Description                                                                   |
 | --------------------- | ----------------------------------------------------------------------------- |
-| `--auth-type <type>`  | Override credential storage (`file`)                                          |
 | `-s, --silent`        | Suppress all output                                                           |
 | `--json`              | Output as JSON                                                                |
 | `--log-level <level>` | Set log level (`error`, `warn`, `notice`, `http`, `info`, `verbose`, `silly`) |
@@ -262,7 +261,7 @@ Log in to a Skywriter server and save credentials.
 skywriter login http://myuser@mysite.com
 ```
 
-Options: `-y, --yes` (set as default without prompting), `--use-env` (read from `SKYWRITER_SECRET` env var)
+Options: `-y, --yes` (set as default without prompting), `--use-env` (read from `SKYWRITER_SECRET` env var), `--auth-store=file` (store credentials in config file instead of OS keychain)
 
 #### `skywriter logout`
 

--- a/pages/skywriter/content.md
+++ b/pages/skywriter/content.md
@@ -245,7 +245,6 @@ skywriter <command>
 
 | Option                | Description                                                                   |
 | --------------------- | ----------------------------------------------------------------------------- |
-| `--auth-type <type>`  | Override credential storage (`file`)                                          |
 | `-s, --silent`        | Suppress all output                                                           |
 | `--json`              | Output as JSON                                                                |
 | `--log-level <level>` | Set log level (`error`, `warn`, `notice`, `http`, `info`, `verbose`, `silly`) |
@@ -260,7 +259,7 @@ Log in to a Skywriter server and save credentials.
 skywriter login http://myuser@mysite.com
 ```
 
-Options: `-y, --yes` (set as default without prompting), `--use-env` (read from `SKYWRITER_SECRET` env var)
+Options: `-y, --yes` (set as default without prompting), `--use-env` (read from `SKYWRITER_SECRET` env var), `--auth-store=file` (store credentials in config file instead of OS keychain)
 
 #### `skywriter logout`
 

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -204,14 +204,14 @@ export const init: CliCommand<[InitOptions?]> = async (ctx, options = {}) => {
       const templateDir = join(cwd, 'template')
       await fs.mkdir(templateDir, {recursive: true})
       await initDirectory(templateDir, {...initOptions, path: templatePath}, fs, {skipEmptyCheck: true})
-      await fs.updateSettingsFile(join(cwd, 'settings.json'), 'template_path', templatePath)
+      await fs.updateJsonProperty(join(cwd, 'settings.json'), ['template_path'], templatePath)
     }
 
     if (slot && slotPath) {
       const slotDir = join(cwd, 'slot')
       await fs.mkdir(slotDir, {recursive: true})
       await initDirectory(slotDir, {...initOptions, path: slotPath}, fs, {skipEmptyCheck: true})
-      await fs.updateSettingsFile(join(cwd, 'settings.json'), 'slot_path', slotPath)
+      await fs.updateJsonProperty(join(cwd, 'settings.json'), ['slot_path'], slotPath)
     }
 
     return
@@ -236,14 +236,14 @@ export const init: CliCommand<[InitOptions?]> = async (ctx, options = {}) => {
       const templateDir = join(cwd, 'template')
       await fs.mkdir(templateDir, {recursive: true})
       await initDirectory(templateDir, {...initOptions, path: templatePath}, fs, {skipEmptyCheck: true})
-      await fs.updateSettingsFile(join(cwd, 'settings.json'), 'template_path', templatePath)
+      await fs.updateJsonProperty(join(cwd, 'settings.json'), ['template_path'], templatePath)
     }
 
     if (slot && slotPath) {
       const slotDir = join(cwd, 'slot')
       await fs.mkdir(slotDir, {recursive: true})
       await initDirectory(slotDir, {...initOptions, path: slotPath}, fs, {skipEmptyCheck: true})
-      await fs.updateSettingsFile(join(cwd, 'settings.json'), 'slot_path', slotPath)
+      await fs.updateJsonProperty(join(cwd, 'settings.json'), ['slot_path'], slotPath)
     }
   }
 }

--- a/src/cli/commands/logout.ts
+++ b/src/cli/commands/logout.ts
@@ -1,5 +1,5 @@
 import {select, confirm} from '@inquirer/prompts'
-import {listServers, deleteCredentials} from '../utils/credentials.ts'
+import {readServerConfig} from '../utils/config.ts'
 import type {CliCommand} from '../utils/types.ts'
 import {createPrefixLog} from '../utils/prefixLog.ts'
 
@@ -31,7 +31,8 @@ export const logout: CliCommand<[LogoutOptions?]> = async (ctx, options = {}) =>
     }
   }
 
-  const servers = await listServers(ctx, cmdLog)
+  const config = await readServerConfig(ctx, cmdLog)
+  const servers = config.listServers()
 
   if (servers.length === 0) {
     cmdLog.info('No servers configured.')
@@ -47,7 +48,7 @@ export const logout: CliCommand<[LogoutOptions?]> = async (ctx, options = {}) =>
       if (!confirmed) return
     }
 
-    await deleteCredentials(ctx, cmdLog, server.serverUrl, server.username)
+    await config.deleteCredentials(server.serverUrl, server.username)
     cmdLog.info(`✓ Logged out from: ${server.serverUrl} (${server.username})`)
   }
 

--- a/src/cli/commands/removeServer.ts
+++ b/src/cli/commands/removeServer.ts
@@ -1,5 +1,5 @@
 import {select, confirm} from '@inquirer/prompts'
-import {listServers, deleteCredentials} from '../utils/credentials.ts'
+import {readServerConfig} from '../utils/config.ts'
 import type {CliCommand, ServerInfo} from '../utils/types.ts'
 import {createPrefixLog} from '../utils/prefixLog.ts'
 
@@ -11,7 +11,8 @@ import {createPrefixLog} from '../utils/prefixLog.ts'
  */
 export const removeServer: CliCommand<[string?]> = async (ctx, url?) => {
   const log = createPrefixLog(ctx.cliName, 'remote remove')
-  const servers = await listServers(ctx, log)
+  const config = await readServerConfig(ctx, log)
+  const servers = config.listServers()
 
   if (servers.length === 0) {
     throw new Error(`No servers configured. Run "${ctx.cliName} login" to add one.`)
@@ -24,7 +25,7 @@ export const removeServer: CliCommand<[string?]> = async (ctx, url?) => {
     })
 
     if (confirmed) {
-      await deleteCredentials(ctx, log, server.serverUrl, server.username)
+      await config.deleteCredentials(server.serverUrl, server.username)
       log.info(`removed server: ${server.serverUrl} (${server.username})`)
     }
   }

--- a/src/cli/commands/sessions.ts
+++ b/src/cli/commands/sessions.ts
@@ -1,4 +1,4 @@
-import {listServers} from '../utils/credentials.ts'
+import {readServerConfig} from '../utils/config.ts'
 import type {CliCommand} from '../utils/types.ts'
 import {createPrefixLog} from '../utils/prefixLog.ts'
 import {logData} from '../utils/logData.ts'
@@ -9,7 +9,8 @@ import {logData} from '../utils/logData.ts'
 export const sessions: CliCommand = async ctx => {
   const json = ctx.json
   const cmdLog = createPrefixLog(ctx.cliName, 'remote list')
-  const servers = await listServers(ctx, cmdLog)
+  const serverConfig = await readServerConfig(ctx, cmdLog)
+  const servers = serverConfig.listServers()
 
   if (servers.length === 0) {
     const message = `No remotes configured. Run "${ctx.cliName} login" to add one.`

--- a/src/cli/commands/switchServer.ts
+++ b/src/cli/commands/switchServer.ts
@@ -1,5 +1,5 @@
 import {select} from '@inquirer/prompts'
-import {listServers, setDefaultServer} from '../utils/credentials.ts'
+import {readServerConfig} from '../utils/config.ts'
 import type {CliCommand} from '../utils/types.ts'
 import {createPrefixLog} from '../utils/prefixLog.ts'
 
@@ -11,7 +11,8 @@ import {createPrefixLog} from '../utils/prefixLog.ts'
  */
 export const switchServer: CliCommand<[string?]> = async (ctx, url?) => {
   const cmdLog = createPrefixLog(ctx.cliName, 'remote switch')
-  const servers = await listServers(ctx, cmdLog)
+  const serverConfig = await readServerConfig(ctx, cmdLog)
+  const servers = serverConfig.listServers()
 
   if (servers.length === 0) {
     throw new Error(`No servers configured. Run "${ctx.cliName} login" to add one.`)
@@ -32,7 +33,7 @@ export const switchServer: CliCommand<[string?]> = async (ctx, url?) => {
       cmdLog.info(`${username}@${parsed.host} is already the active server.`)
       return
     }
-    await setDefaultServer(ctx, cmdLog, server.serverUrl, server.username)
+    await serverConfig.setDefaultServer(server.serverUrl, server.username)
     return
   }
 
@@ -56,5 +57,5 @@ export const switchServer: CliCommand<[string?]> = async (ctx, url?) => {
     return
   }
 
-  await setDefaultServer(ctx, cmdLog, selected.serverUrl, selected.username)
+  await serverConfig.setDefaultServer(selected.serverUrl, selected.username)
 }

--- a/src/cli/commands/whoami.ts
+++ b/src/cli/commands/whoami.ts
@@ -1,4 +1,4 @@
-import {listServers, retrieveCredentials} from '../utils/credentials.ts'
+import {readServerConfig} from '../utils/config.ts'
 import type {CliCommand} from '../utils/types.ts'
 import {createPrefixLog} from '../utils/prefixLog.ts'
 import {createLoggedFetch} from '../utils/loggedFetch.ts'
@@ -11,7 +11,8 @@ export const whoami: CliCommand = async ctx => {
   const json = ctx.json
   const cmdLog = createPrefixLog(ctx.cliName, 'whoami')
   const fetch = createLoggedFetch(cmdLog)
-  const servers = await listServers(ctx, cmdLog)
+  const config = await readServerConfig(ctx, cmdLog)
+  const servers = config.listServers()
 
   if (servers.length === 0) {
     const message = `Not logged in. Run "${ctx.cliName} login" to authenticate.`
@@ -34,7 +35,7 @@ export const whoami: CliCommand = async ctx => {
     throw new Error(message)
   }
 
-  const defaultServer = await retrieveCredentials(ctx, cmdLog, active.serverUrl, active.username)
+  const defaultServer = await config.retrieveCredentials(active.serverUrl, active.username)
   if (!defaultServer) {
     const message = `Credentials expired for ${active.username}@${new URL(active.serverUrl).host}. Run "${ctx.cliName} login" to re-authenticate.`
     if (json) {

--- a/src/cli/utils/config.ts
+++ b/src/cli/utils/config.ts
@@ -1,10 +1,21 @@
 #!/usr/bin/env node
-import {getDefaultServer, retrieveCredentials, listServers} from './credentials.ts'
+import {chmod} from 'node:fs/promises'
 import {parseDocumentPath} from './parseDocumentPath.ts'
-import type {CliContext} from './types.ts'
+import type {CliContext, ServerInfo} from './types.ts'
 import type {PrefixLog} from './prefixLog.ts'
+import {createLoggedFs} from './createLoggedFs.ts'
+import {
+  type ServerConfig,
+  validateConfigJson,
+  getConfigFilePath,
+  serverKey,
+  parseServerKey,
+  getOsCredentialBackend,
+  createCredentialStore,
+  getCredentialBackendName,
+} from './credentials.ts'
 
-interface CliConfig {
+interface ServerCredentials {
   serverUrl: string
   username: string
   password: string
@@ -16,20 +27,143 @@ interface CliConfig {
 export function sanitizeServerUrl(url: string): string {
   try {
     const parsed = new URL(url)
-    // Return only protocol and host (strips path, query, hash, trailing slashes)
     return `${parsed.protocol}//${parsed.host}`
   } catch {
-    throw new Error(`Invalid server URL: ${url}`)
+    throw new Error(`Invalid server URL`)
   }
 }
 
 /**
+ * Server config class — reads config once, all methods operate on the cached data.
+ */
+export class CliServerConfig {
+  private config: ServerConfig
+  private ctx: CliContext
+  private cmdLog: PrefixLog
+  private fs: ReturnType<typeof createLoggedFs>
+
+  constructor(ctx: CliContext, cmdLog: PrefixLog, config: ServerConfig) {
+    this.config = config
+    this.ctx = ctx
+    this.cmdLog = cmdLog
+    this.fs = createLoggedFs(cmdLog)
+  }
+
+  listServers(): ServerInfo[] {
+    return Object.keys(this.config.servers).map(key => {
+      const {serverUrl, username} = parseServerKey(key)
+      return {serverUrl, username, active: this.config.active === key}
+    })
+  }
+
+  async storeCredentials(
+    serverUrl: string,
+    username: string,
+    password: string,
+    options: {setAsDefault?: boolean; authStore?: 'file'} = {},
+  ): Promise<void> {
+    const {setAsDefault = true, authStore} = options
+    const configPath = getConfigFilePath(this.ctx.cliId)
+    const key = serverKey(serverUrl, username)
+
+    // Add server entry first (so file-based store can nest password inside it)
+    await this.fs.updateJsonProperty(configPath, ['servers', key], {})
+    await chmod(configPath, 0o600)
+
+    // Determine backend: explicit file override, or auto-detect based on OS
+    const backend = authStore === 'file' ? 'file' : getOsCredentialBackend()
+    const store = createCredentialStore(backend, this.ctx, this.cmdLog, this.config)
+    await store.store(serverUrl, username, password)
+    this.cmdLog.info(`saving credentials for ${username}@${new URL(serverUrl).host}`)
+
+    // Set as active if requested
+    if (setAsDefault) {
+      await this.fs.updateJsonProperty(configPath, ['active'], key)
+      await chmod(configPath, 0o600)
+    }
+  }
+
+  async retrieveCredentials(serverUrl: string, username: string): Promise<ServerCredentials | null> {
+    const key = serverKey(serverUrl, username)
+    const hasPassword = !!this.config.servers[key]?.password
+    const backend = hasPassword ? 'file' : getOsCredentialBackend()
+    const store = createCredentialStore(backend, this.ctx, this.cmdLog, this.config)
+    this.cmdLog.info(`accessing credentials for ${username}@${new URL(serverUrl).host}`)
+    const password = await store.retrieve(serverUrl, username)
+
+    if (!password) {
+      return null
+    }
+
+    return {serverUrl, username, password}
+  }
+
+  async deleteCredentials(serverUrl: string, username: string): Promise<void> {
+    const key = serverKey(serverUrl, username)
+    const hasPassword = !!this.config.servers[key]?.password
+    const backend = hasPassword ? 'file' : getOsCredentialBackend()
+    const store = createCredentialStore(backend, this.ctx, this.cmdLog, this.config)
+    await store.delete(serverUrl, username)
+    this.cmdLog.info(`deleting credentials for ${username}@${new URL(serverUrl).host}`)
+
+    const configPath = getConfigFilePath(this.ctx.cliId)
+
+    // Nothing to remove if config file has no servers
+    if (Object.keys(this.config.servers).length === 0) return
+
+    // Remove server entry
+    await this.fs.removeJsonProperty(configPath, ['servers', key])
+    await chmod(configPath, 0o600)
+
+    // If this was the active server, clear active
+    if (this.config.active === key) {
+      await this.fs.updateJsonProperty(configPath, ['active'], null)
+      await chmod(configPath, 0o600)
+    }
+  }
+
+  async setDefaultServer(serverUrl: string, username: string): Promise<void> {
+    const configPath = getConfigFilePath(this.ctx.cliId)
+    const key = serverKey(serverUrl, username)
+    await this.fs.updateJsonProperty(configPath, ['active'], key)
+    await chmod(configPath, 0o600)
+  }
+
+  async getDefaultServer(): Promise<ServerCredentials | null> {
+    if (!this.config.active) {
+      return null
+    }
+
+    const {serverUrl, username} = parseServerKey(this.config.active)
+    return await this.retrieveCredentials(serverUrl, username)
+  }
+
+  getCredentialBackendName(): string {
+    return getCredentialBackendName()
+  }
+}
+
+/**
+ * Read server config and return a CliServerConfig instance.
+ * All methods on the returned object operate on the single read.
+ */
+export async function readServerConfig(ctx: CliContext, cmdLog: PrefixLog): Promise<CliServerConfig> {
+  const configFilePath = getConfigFilePath(ctx.cliId)
+  const fs = createLoggedFs(cmdLog)
+  let config: ServerConfig
+  try {
+    const content = await fs.readFile(configFilePath)
+    config = validateConfigJson(JSON.parse(content))
+  } catch {
+    config = {active: null, servers: {}}
+  }
+  return new CliServerConfig(ctx, cmdLog, config)
+}
+
+// --- Source resolution helpers (unchanged) ---
+
+/**
  * Parse a pull/clone source argument into serverUrl + document path.
- *
- * Accepts:
- *   /meow                          → uses defaultServerUrl + /meow
- *   http://localhost:3000/meow     → server http://localhost:3000, path /meow
- *   http://localhost:3000/meow.git → same, strips .git
  */
 function parseSource(source: string, defaultServerUrl?: string): {serverUrl: string; path: string} {
   if (source.startsWith('http://') || source.startsWith('https://')) {
@@ -45,11 +179,6 @@ function parseSource(source: string, defaultServerUrl?: string): {serverUrl: str
   return {serverUrl: defaultServerUrl, path: parseDocumentPath(source)}
 }
 
-/**
- * Parsed and resolved source: server URL, document path, and credentials.
- * Attached to CliContext by push/pull commands so downstream handlers
- * don't need to re-parse the positional argument.
- */
 interface ResolvedSource {
   serverUrl: string
   documentPath: string
@@ -60,13 +189,12 @@ interface ResolvedSource {
 
 /**
  * Parse a source argument and resolve credentials for the target server.
- * Handles all source formats: full URL, /path, bare name.
  */
 export async function resolveSource(ctx: CliContext, log: PrefixLog, source: string): Promise<ResolvedSource> {
   const defaultConfig = await readConfig(ctx, log).catch(() => null)
   const {serverUrl, path: documentPath} = parseSource(source, defaultConfig?.serverUrl)
 
-  let config: CliConfig
+  let config: ServerCredentials
   if (defaultConfig && serverUrl === defaultConfig.serverUrl) {
     config = defaultConfig
   } else {
@@ -77,20 +205,20 @@ export async function resolveSource(ctx: CliContext, log: PrefixLog, source: str
   return {serverUrl, documentPath, username: config.username, password: config.password, auth}
 }
 
-/**
- * Look up credentials for a specific server URL from the stored server list.
- */
-async function getCredentialsForServer(ctx: CliContext, log: PrefixLog, serverUrl: string): Promise<CliConfig> {
-  const servers = await listServers(ctx, log)
+async function getCredentialsForServer(ctx: CliContext, log: PrefixLog, serverUrl: string): Promise<ServerCredentials> {
+  const serverConfig = await readServerConfig(ctx, log)
+  const servers = serverConfig.listServers()
   const match = servers.find(s => s.serverUrl === serverUrl)
 
   if (!match) {
-    throw new Error(`No credentials for ${serverUrl}. Run: ${ctx.cliName} login`)
+    throw new Error(`No credentials for ${new URL(serverUrl).host}. Run: ${ctx.cliName} login`)
   }
 
-  const credentials = await retrieveCredentials(ctx, log, match.serverUrl, match.username)
+  const credentials = await serverConfig.retrieveCredentials(match.serverUrl, match.username)
   if (!credentials) {
-    throw new Error(`Credentials expired or missing for ${serverUrl} (${match.username}). Run: ${ctx.cliName} login`)
+    throw new Error(
+      `Credentials expired or missing for ${match.username}@${new URL(serverUrl).host}. Run: ${ctx.cliName} login`,
+    )
   }
 
   return credentials
@@ -104,20 +232,19 @@ export async function readConfig(
   log: PrefixLog,
   serverUrl?: string,
   username?: string,
-): Promise<CliConfig> {
+): Promise<ServerCredentials> {
+  const serverConfig = await readServerConfig(ctx, log)
   let credentials
 
   if (serverUrl && username) {
-    // Get specific server credentials
-    credentials = await retrieveCredentials(ctx, log, serverUrl, username)
+    credentials = await serverConfig.retrieveCredentials(serverUrl, username)
     if (!credentials) {
-      throw new Error(`No credentials found for ${serverUrl} (${username})`)
+      throw new Error(`No credentials found for ${username}@${new URL(serverUrl).host}`)
     }
   } else {
-    // Get default server credentials
-    credentials = await getDefaultServer(ctx, log)
+    credentials = await serverConfig.getDefaultServer()
     if (!credentials) {
-      const servers = await listServers(ctx, log)
+      const servers = serverConfig.listServers()
       if (servers.length === 0) {
         throw new Error(`Not logged in. Please run: ${ctx.cliName} login`)
       } else {

--- a/src/cli/utils/credentials.ts
+++ b/src/cli/utils/credentials.ts
@@ -2,34 +2,27 @@
 import {exec} from 'node:child_process'
 import {promisify} from 'node:util'
 import {platform} from 'node:os'
-import {readFile, writeFile, chmod} from 'node:fs/promises'
+import {chmod} from 'node:fs/promises'
 import {homedir} from 'node:os'
 import {join} from 'node:path'
-import type {CliContext, ServerInfo} from './types.ts'
+import type {CliContext} from './types.ts'
 import type {PrefixLog} from './prefixLog.ts'
 import {createLoggedFs} from './createLoggedFs.ts'
-import log from './log.ts'
 
 const execAsync = promisify(exec)
-
-interface ServerCredentials {
-  serverUrl: string
-  username: string
-  password: string
-}
 
 function getKeychainService(cliId: string): string {
   return `com.${cliId}.cli`
 }
 
-function getConfigFilePath(cliId: string): string {
+export function getConfigFilePath(cliId: string): string {
   return join(homedir(), `.${cliId}.json`)
 }
 
 /**
  * Build a server key like "https://reggi@domain.com" from serverUrl and username
  */
-function serverKey(serverUrl: string, username: string): string {
+export function serverKey(serverUrl: string, username: string): string {
   const url = new URL(serverUrl)
   url.username = username
   return url.href.replace(/\/$/, '')
@@ -38,7 +31,7 @@ function serverKey(serverUrl: string, username: string): string {
 /**
  * Parse a server key like "https://reggi@domain.com" into serverUrl and username
  */
-function parseServerKey(key: string): {serverUrl: string; username: string} {
+export function parseServerKey(key: string): {serverUrl: string; username: string} {
   const url = new URL(key)
   const username = url.username
   url.username = ''
@@ -48,7 +41,7 @@ function parseServerKey(key: string): {serverUrl: string; username: string} {
 /**
  * Internal config format: {active, servers} object
  */
-interface ServerConfig {
+export interface ServerConfig {
   active: string | null
   servers: Record<string, Record<string, unknown>>
 }
@@ -57,7 +50,7 @@ interface ServerConfig {
  * Validate the shape of the config file JSON.
  * Returns a valid ServerConfig or throws with a descriptive message.
  */
-function validateConfigJson(data: unknown): ServerConfig {
+export function validateConfigJson(data: unknown): ServerConfig {
   if (data === null || typeof data !== 'object' || Array.isArray(data)) {
     throw new Error('Config file must contain a JSON object')
   }
@@ -98,30 +91,9 @@ function validateConfigJson(data: unknown): ServerConfig {
 }
 
 /**
- * Read server config with logging and validation
+ * Detect which credential storage backend to use based on OS
  */
-async function readServerConfigLogged(cliId: string, cmdLog: PrefixLog): Promise<ServerConfig> {
-  const configFilePath = getConfigFilePath(cliId)
-  const fs = createLoggedFs(cmdLog)
-  try {
-    const content = await fs.readFile(configFilePath)
-    return validateConfigJson(JSON.parse(content))
-  } catch {
-    return {active: null, servers: {}}
-  }
-}
-
-/**
- * Detect which credential storage backend to use
- * Can be overridden to 'file' via --auth-type=file flag
- * Only 'file' override is allowed - other backends are auto-detected based on OS
- */
-function getCredentialBackend(authType?: 'file'): 'keychain' | 'keyring' | 'wincred' | 'file' {
-  // Allow override to file-based storage via --auth-type=file flag
-  if (authType === 'file') {
-    return 'file'
-  }
-
+export function getOsCredentialBackend(): 'keychain' | 'keyring' | 'wincred' | 'file' {
   const os = platform()
 
   if (os === 'darwin') {
@@ -142,7 +114,7 @@ function getCredentialBackend(authType?: 'file'): 'keychain' | 'keyring' | 'winc
 class KeychainCredentialStore {
   private cliName: string
 
-  constructor(cliName: string) {
+  constructor(cliName: string, _config: ServerConfig) {
     this.cliName = cliName
   }
 
@@ -185,7 +157,7 @@ class KeyringCredentialStore {
   private cliId: string
   private cliName: string
 
-  constructor(cliId: string, cliName: string) {
+  constructor(cliId: string, cliName: string, _config: ServerConfig) {
     this.cliId = cliId
     this.cliName = cliName
     this.keychainService = getKeychainService(cliId)
@@ -227,7 +199,7 @@ class KeyringCredentialStore {
 class WinCredentialStore {
   private keychainService: string
 
-  constructor(cliId: string) {
+  constructor(cliId: string, _config: ServerConfig) {
     this.keychainService = getKeychainService(cliId)
   }
 
@@ -267,213 +239,73 @@ class WinCredentialStore {
 
 /**
  * File-based credential storage (fallback with encryption warning)
+ * Stores passwords in the config file under servers.<key>.password
  */
 class FileCredentialStore {
-  private filePath: string
+  private cliId: string
+  private config: ServerConfig
+  private fs: ReturnType<typeof createLoggedFs>
+  private cmdLog: PrefixLog
 
-  constructor(cliId: string) {
-    this.filePath = join(homedir(), `.${cliId}-cli-credentials.json`)
+  constructor(cliId: string, cmdLog: PrefixLog, config: ServerConfig) {
+    this.cliId = cliId
+    this.config = config
+    this.fs = createLoggedFs(cmdLog)
+    this.cmdLog = cmdLog
   }
 
   async store(serverUrl: string, username: string, password: string): Promise<void> {
-    const credentials = await this.readAll()
-    const key = `${serverUrl}:${username}`
-    credentials[key] = {serverUrl, username, password}
+    const configPath = getConfigFilePath(this.cliId)
+    const key = serverKey(serverUrl, username)
+    await this.fs.updateJsonPropertyRedacted(configPath, ['servers', key, 'password'], password)
+    await chmod(configPath, 0o600)
 
-    await writeFile(this.filePath, JSON.stringify(credentials, null, 2), 'utf-8')
-    await chmod(this.filePath, 0o600)
-
-    log.warn('⚠️  Warning: Credentials stored in plain text file. Consider using a secure credential store.')
+    this.cmdLog.warn('Credentials stored in plain text file. Consider using a secure credential store.')
   }
 
   async retrieve(serverUrl: string, username: string): Promise<string | null> {
-    const credentials = await this.readAll()
-    const key = `${serverUrl}:${username}`
-    return credentials[key]?.password || null
+    const key = serverKey(serverUrl, username)
+    const password = this.config.servers[key]?.password
+    return typeof password === 'string' ? password : null
   }
 
   async delete(serverUrl: string, username: string): Promise<void> {
-    const credentials = await this.readAll()
-    const key = `${serverUrl}:${username}`
-    delete credentials[key]
-
-    if (Object.keys(credentials).length === 0) {
-      // If no credentials left, just write empty object
-      await writeFile(this.filePath, '{}', 'utf-8')
-    } else {
-      await writeFile(this.filePath, JSON.stringify(credentials, null, 2), 'utf-8')
-    }
-  }
-
-  private async readAll(): Promise<Record<string, ServerCredentials>> {
+    const configPath = getConfigFilePath(this.cliId)
+    const key = serverKey(serverUrl, username)
     try {
-      const content = await readFile(this.filePath, 'utf-8')
-      return JSON.parse(content)
+      await this.fs.removeJsonProperty(configPath, ['servers', key, 'password'])
     } catch {
-      return {}
+      // Ignore errors if config file doesn't exist
     }
   }
-}
-
-async function readServerList(cliId: string, log: PrefixLog): Promise<ServerInfo[]> {
-  const config = await readServerConfigLogged(cliId, log)
-  return Object.keys(config.servers).map(key => {
-    const {serverUrl, username} = parseServerKey(key)
-    return {serverUrl, username, active: config.active === key}
-  })
-}
-
-async function _writeServerConfig(cliId: string, config: ServerConfig): Promise<void> {
-  const configFilePath = getConfigFilePath(cliId)
-  const {writeFile} = await import('node:fs/promises')
-  await writeFile(configFilePath, JSON.stringify(config, null, 2) + '\n', 'utf-8')
-  await chmod(configFilePath, 0o600)
 }
 
 /**
- * Get the appropriate credential store for the current platform
+ * Create a credential store for the given backend
  */
-function getCredentialStore(ctx: CliContext) {
-  const backend = getCredentialBackend(ctx.authType)
-
+export function createCredentialStore(
+  backend: 'keychain' | 'keyring' | 'wincred' | 'file',
+  ctx: CliContext,
+  cmdLog: PrefixLog,
+  config: ServerConfig,
+) {
   switch (backend) {
     case 'keychain':
-      return new KeychainCredentialStore(ctx.cliName)
+      return new KeychainCredentialStore(ctx.cliName, config)
     case 'keyring':
-      return new KeyringCredentialStore(ctx.cliId, ctx.cliName)
+      return new KeyringCredentialStore(ctx.cliId, ctx.cliName, config)
     case 'wincred':
-      return new WinCredentialStore(ctx.cliId)
+      return new WinCredentialStore(ctx.cliId, config)
     case 'file':
-      return new FileCredentialStore(ctx.cliId)
+      return new FileCredentialStore(ctx.cliId, cmdLog, config)
   }
-}
-
-/**
- * Store credentials for a server
- */
-export async function storeCredentials(
-  ctx: CliContext,
-  cmdLog: PrefixLog,
-  serverUrl: string,
-  username: string,
-  password: string,
-  setAsDefault: boolean = true,
-): Promise<void> {
-  const store = getCredentialStore(ctx)
-  await store.store(serverUrl, username, password)
-  cmdLog.info(`saving credentials for ${username}@${new URL(serverUrl).host}`)
-
-  const configPath = getConfigFilePath(ctx.cliId)
-  const fs = createLoggedFs(cmdLog)
-  const key = serverKey(serverUrl, username)
-
-  // Add server entry
-  await fs.updateJsonProperty(configPath, ['servers', key], {})
-  await chmod(configPath, 0o600)
-
-  // Set as active if requested
-  if (setAsDefault) {
-    await fs.updateJsonProperty(configPath, ['active'], key)
-    await chmod(configPath, 0o600)
-  }
-}
-
-/**
- * Retrieve credentials for a server
- */
-export async function retrieveCredentials(
-  ctx: CliContext,
-  cmdLog: PrefixLog,
-  serverUrl: string,
-  username: string,
-): Promise<ServerCredentials | null> {
-  const store = getCredentialStore(ctx)
-  cmdLog.info(`accessing credentials for ${username}@${new URL(serverUrl).host}`)
-  const password = await store.retrieve(serverUrl, username)
-
-  if (!password) {
-    return null
-  }
-
-  return {serverUrl, username, password}
-}
-
-/**
- * Delete credentials for a server
- */
-export async function deleteCredentials(
-  ctx: CliContext,
-  cmdLog: PrefixLog,
-  serverUrl: string,
-  username: string,
-): Promise<void> {
-  const store = getCredentialStore(ctx)
-  await store.delete(serverUrl, username)
-  cmdLog.info(`deleting credentials for ${username}@${new URL(serverUrl).host}`)
-
-  const configPath = getConfigFilePath(ctx.cliId)
-  const fs = createLoggedFs(cmdLog)
-  const key = serverKey(serverUrl, username)
-
-  // Read current config to check if this was active
-  const config = await readServerConfigLogged(ctx.cliId, cmdLog)
-
-  // Nothing to remove if config file has no servers
-  if (Object.keys(config.servers).length === 0) return
-
-  // Remove server entry
-  await fs.removeJsonProperty(configPath, ['servers', key])
-  await chmod(configPath, 0o600)
-
-  // If this was the active server, clear active
-  if (config.active === key) {
-    await fs.updateJsonProperty(configPath, ['active'], null)
-    await chmod(configPath, 0o600)
-  }
-}
-
-/**
- * List all stored server configurations
- */
-export async function listServers(ctx: CliContext, cmdLog: PrefixLog): Promise<ServerInfo[]> {
-  return await readServerList(ctx.cliId, cmdLog)
-}
-
-/**
- * Get the default server configuration
- */
-export async function getDefaultServer(ctx: CliContext, cmdLog: PrefixLog): Promise<ServerCredentials | null> {
-  const config = await readServerConfigLogged(ctx.cliId, cmdLog)
-
-  if (!config.active) {
-    return null
-  }
-
-  const {serverUrl, username} = parseServerKey(config.active)
-  return await retrieveCredentials(ctx, cmdLog, serverUrl, username)
-}
-
-/**
- * Set a server as the default
- */
-export async function setDefaultServer(
-  ctx: CliContext,
-  cmdLog: PrefixLog,
-  serverUrl: string,
-  username: string,
-): Promise<void> {
-  const configPath = getConfigFilePath(ctx.cliId)
-  const fs = createLoggedFs(cmdLog)
-  const key = serverKey(serverUrl, username)
-  await fs.updateJsonProperty(configPath, ['active'], key)
-  await chmod(configPath, 0o600)
 }
 
 /**
  * Get credentials backend name for display
  */
 export function getCredentialBackendName(): string {
-  const backend = getCredentialBackend()
+  const backend = getOsCredentialBackend()
   const names = {
     keychain: 'macOS Keychain',
     keyring: 'Linux Secret Service',

--- a/src/cli/utils/types.ts
+++ b/src/cli/utils/types.ts
@@ -8,8 +8,6 @@ export interface CliContext {
   cliId: string
   /** The current working directory */
   cwd: string
-  /** Override credential storage to use file-based storage instead of system keychain */
-  authType?: 'file'
   /** Suppress all proc-log output (--silent) */
   silent?: boolean
   /** Output as JSON (--json) */

--- a/test/cli/commands/sessions.test.ts
+++ b/test/cli/commands/sessions.test.ts
@@ -5,11 +5,13 @@ import {stripAnsi} from '../../helpers/stripAnsi.ts'
 // Mock data
 let mockServers: Array<{serverUrl: string; username: string; active: boolean}> = []
 
-// Mock credentials module
-mock.module('../../../src/cli/utils/credentials.ts', {
+// Mock config module
+mock.module('../../../src/cli/utils/config.ts', {
   namedExports: {
-    listServers: async () => mockServers,
-    getCredentialBackendName: () => 'Test Backend',
+    readServerConfig: async () => ({
+      listServers: () => mockServers,
+      getCredentialBackendName: () => 'Test Backend',
+    }),
   },
 })
 

--- a/test/cli/commands/whoami.test.ts
+++ b/test/cli/commands/whoami.test.ts
@@ -20,24 +20,21 @@ let mockServers: ServerInfo[] = []
 let mockCredentials: {serverUrl: string; username: string; password: string} | null = null
 let mockFetchResponse: {ok: boolean; status: number; statusText: string} = {ok: true, status: 200, statusText: 'OK'}
 
-// Mock credentials module
-mock.module('../../../src/cli/utils/credentials.ts', {
+// Mock config module
+mock.module('../../../src/cli/utils/config.ts', {
   namedExports: {
-    listServers: async (_ctx: unknown, cmdLog: PrefixLog) => {
-      if (mockServers.length > 0) {
-        cmdLog.fs('reading ~/.wondoc.json')
-      }
-      return mockServers
-    },
-    retrieveCredentials: async (_ctx: unknown, cmdLog: PrefixLog, serverUrl: string, username: string) => {
-      cmdLog.info(`accessing credentials for ${username}@${new URL(serverUrl).host}`)
-      return mockCredentials
-    },
-    getCredentialBackendName: () => 'test-backend',
-    storeCredentials: async () => {},
-    deleteCredentials: async () => {},
-    getDefaultServer: async () => null,
-    setDefaultServer: async () => {},
+    readServerConfig: async (_ctx: unknown, cmdLog: {info: (msg: string) => void; fs: (msg: string) => void}) => ({
+      listServers: () => {
+        if (mockServers.length > 0) {
+          cmdLog.fs('reading ~/.wondoc.json')
+        }
+        return mockServers
+      },
+      retrieveCredentials: async (serverUrl: string, username: string) => {
+        cmdLog.info(`accessing credentials for ${username}@${new URL(serverUrl).host}`)
+        return mockCredentials
+      },
+    }),
   },
 })
 

--- a/test/cli/utils/credentials.linux.test.ts
+++ b/test/cli/utils/credentials.linux.test.ts
@@ -57,8 +57,36 @@ mock.module('node:os', {
 })
 
 // Import after mocking
-const {storeCredentials, retrieveCredentials, deleteCredentials, listServers, getCredentialBackendName} =
-  await import('../../../src/cli/utils/credentials.ts')
+const {getCredentialBackendName} = await import('../../../src/cli/utils/credentials.ts')
+const {readServerConfig} = await import('../../../src/cli/utils/config.ts')
+
+// Helper: read config and call methods
+async function storeCredentials(
+  ctx: CliContext,
+  log: PrefixLog,
+  serverUrl: string,
+  username: string,
+  password: string,
+  setAsDefault = true,
+) {
+  const config = await readServerConfig(ctx, log)
+  await config.storeCredentials(serverUrl, username, password, {setAsDefault})
+}
+
+async function retrieveCredentials(ctx: CliContext, log: PrefixLog, serverUrl: string, username: string) {
+  const config = await readServerConfig(ctx, log)
+  return config.retrieveCredentials(serverUrl, username)
+}
+
+async function deleteCredentials(ctx: CliContext, log: PrefixLog, serverUrl: string, username: string) {
+  const config = await readServerConfig(ctx, log)
+  await config.deleteCredentials(serverUrl, username)
+}
+
+async function listServers(ctx: CliContext, log: PrefixLog) {
+  const config = await readServerConfig(ctx, log)
+  return config.listServers()
+}
 
 // Capture proc-log output
 let consoleOutput: string[] = []

--- a/test/cli/utils/credentials.macos.test.ts
+++ b/test/cli/utils/credentials.macos.test.ts
@@ -57,15 +57,46 @@ mock.module('node:os', {
 })
 
 // Import after mocking
-const {
-  storeCredentials,
-  retrieveCredentials,
-  deleteCredentials,
-  listServers,
-  getDefaultServer,
-  setDefaultServer,
-  getCredentialBackendName,
-} = await import('../../../src/cli/utils/credentials.ts')
+const {getCredentialBackendName} = await import('../../../src/cli/utils/credentials.ts')
+const {readServerConfig} = await import('../../../src/cli/utils/config.ts')
+
+// Helper: read config and call methods
+async function storeCredentials(
+  ctx: CliContext,
+  log: PrefixLog,
+  serverUrl: string,
+  username: string,
+  password: string,
+  setAsDefault = true,
+) {
+  const config = await readServerConfig(ctx, log)
+  await config.storeCredentials(serverUrl, username, password, {setAsDefault})
+}
+
+async function retrieveCredentials(ctx: CliContext, log: PrefixLog, serverUrl: string, username: string) {
+  const config = await readServerConfig(ctx, log)
+  return config.retrieveCredentials(serverUrl, username)
+}
+
+async function deleteCredentials(ctx: CliContext, log: PrefixLog, serverUrl: string, username: string) {
+  const config = await readServerConfig(ctx, log)
+  await config.deleteCredentials(serverUrl, username)
+}
+
+async function listServers(ctx: CliContext, log: PrefixLog) {
+  const config = await readServerConfig(ctx, log)
+  return config.listServers()
+}
+
+async function getDefaultServer(ctx: CliContext, log: PrefixLog) {
+  const config = await readServerConfig(ctx, log)
+  return config.getDefaultServer()
+}
+
+async function setDefaultServer(ctx: CliContext, log: PrefixLog, serverUrl: string, username: string) {
+  const config = await readServerConfig(ctx, log)
+  await config.setDefaultServer(serverUrl, username)
+}
 
 // Capture proc-log output
 let consoleOutput: string[] = []

--- a/test/cli/utils/credentials.windows.test.ts
+++ b/test/cli/utils/credentials.windows.test.ts
@@ -57,8 +57,36 @@ mock.module('node:os', {
 })
 
 // Import after mocking
-const {storeCredentials, retrieveCredentials, deleteCredentials, listServers, getCredentialBackendName} =
-  await import('../../../src/cli/utils/credentials.ts')
+const {getCredentialBackendName} = await import('../../../src/cli/utils/credentials.ts')
+const {readServerConfig} = await import('../../../src/cli/utils/config.ts')
+
+// Helper: read config and call methods
+async function storeCredentials(
+  ctx: CliContext,
+  log: PrefixLog,
+  serverUrl: string,
+  username: string,
+  password: string,
+  setAsDefault = true,
+) {
+  const config = await readServerConfig(ctx, log)
+  await config.storeCredentials(serverUrl, username, password, {setAsDefault})
+}
+
+async function retrieveCredentials(ctx: CliContext, log: PrefixLog, serverUrl: string, username: string) {
+  const config = await readServerConfig(ctx, log)
+  return config.retrieveCredentials(serverUrl, username)
+}
+
+async function deleteCredentials(ctx: CliContext, log: PrefixLog, serverUrl: string, username: string) {
+  const config = await readServerConfig(ctx, log)
+  await config.deleteCredentials(serverUrl, username)
+}
+
+async function listServers(ctx: CliContext, log: PrefixLog) {
+  const config = await readServerConfig(ctx, log)
+  return config.listServers()
+}
 
 // Capture proc-log output
 let consoleOutput: string[] = []

--- a/test/cli/utils/pullViaGit.test.ts
+++ b/test/cli/utils/pullViaGit.test.ts
@@ -50,10 +50,7 @@ mock.module('node:fs/promises', {
       const pathStr = String(args[0])
       const basename = pathStr.split('/').pop() || ''
       if (basename === '.wondoc.json') {
-        return JSON.stringify({active: mockServerKey, servers: {[mockServerKey]: {}}})
-      }
-      if (basename === '.wondoc-cli-credentials.json') {
-        return JSON.stringify({[`${mockConfig.serverUrl}:${mockConfig.username}`]: mockConfig})
+        return JSON.stringify({active: mockServerKey, servers: {[mockServerKey]: {password: mockConfig.password}}})
       }
       return (originalReadFile as (...a: unknown[]) => Promise<string>)(...args)
     },
@@ -173,7 +170,7 @@ mock.module('node:child_process', {
 // Import after mocking
 const {pullViaGit} = await import('../../../src/cli/utils/pullViaGit.ts')
 import {createMockCliContext} from '../test-context.ts'
-const mockCliContext = createMockCliContext({authType: 'file'})
+const mockCliContext = createMockCliContext()
 
 describe('pullViaGit', () => {
   const createdDirs: string[] = []

--- a/test/cli/utils/pullViaTar.test.ts
+++ b/test/cli/utils/pullViaTar.test.ts
@@ -48,10 +48,7 @@ mock.module('node:fs/promises', {
       const pathStr = String(args[0])
       const basename = pathStr.split('/').pop() || ''
       if (basename === '.wondoc.json') {
-        return JSON.stringify({active: mockServerKey, servers: {[mockServerKey]: {}}})
-      }
-      if (basename === '.wondoc-cli-credentials.json') {
-        return JSON.stringify({[`${mockConfig.serverUrl}:${mockConfig.username}`]: mockConfig})
+        return JSON.stringify({active: mockServerKey, servers: {[mockServerKey]: {password: mockConfig.password}}})
       }
       return (originalReadFile as (...a: unknown[]) => Promise<string>)(...args)
     },
@@ -158,7 +155,7 @@ mock.module('node:child_process', {
 // Import after mocking
 const {pullViaTar} = await import('../../../src/cli/utils/pullViaTar.ts')
 import {createMockCliContext} from '../test-context.ts'
-const mockCliContext = createMockCliContext({authType: 'file'})
+const mockCliContext = createMockCliContext()
 
 async function pathExists(path: string): Promise<boolean> {
   try {

--- a/test/cli/utils/pushViaGit.test.ts
+++ b/test/cli/utils/pushViaGit.test.ts
@@ -52,10 +52,7 @@ mock.module('node:fs/promises', {
       const pathStr = String(args[0])
       const basename = pathStr.split('/').pop() || ''
       if (basename === '.wondoc.json') {
-        return JSON.stringify({active: mockServerKey, servers: {[mockServerKey]: {}}})
-      }
-      if (basename === '.wondoc-cli-credentials.json') {
-        return JSON.stringify({[`${mockConfig.serverUrl}:${mockConfig.username}`]: mockConfig})
+        return JSON.stringify({active: mockServerKey, servers: {[mockServerKey]: {password: mockConfig.password}}})
       }
       return (originalReadFile as (...a: unknown[]) => Promise<string>)(...args)
     },
@@ -177,7 +174,7 @@ mock.module('node:child_process', {
 // Import after mocking
 const {pushViaGit} = await import('../../../src/cli/utils/pushViaGit.ts')
 import {createMockCliContext} from '../test-context.ts'
-const mockCliContext = createMockCliContext({authType: 'file'})
+const mockCliContext = createMockCliContext()
 
 describe('pushViaGit', () => {
   const createdDirs: string[] = []

--- a/test/cli/utils/pushViaTar.test.ts
+++ b/test/cli/utils/pushViaTar.test.ts
@@ -48,10 +48,7 @@ mock.module('node:fs/promises', {
       const pathStr = String(args[0])
       const basename = pathStr.split('/').pop() || ''
       if (basename === '.wondoc.json') {
-        return JSON.stringify({active: mockServerKey, servers: {[mockServerKey]: {}}})
-      }
-      if (basename === '.wondoc-cli-credentials.json') {
-        return JSON.stringify({[`${mockConfig.serverUrl}:${mockConfig.username}`]: mockConfig})
+        return JSON.stringify({active: mockServerKey, servers: {[mockServerKey]: {password: mockConfig.password}}})
       }
       return (originalReadFile as (...a: unknown[]) => Promise<string>)(...args)
     },
@@ -93,7 +90,7 @@ mock.module('../../../src/cli/pathOperations/deletePathUploads.ts', {
 // Import after mocking
 const {pushViaTar} = await import('../../../src/cli/utils/pushViaTar.ts')
 import {createMockCliContext} from '../test-context.ts'
-const mockCliContext = createMockCliContext({authType: 'file'})
+const mockCliContext = createMockCliContext()
 
 /**
  * Extract filenames from a tar.gz buffer


### PR DESCRIPTION
fixes https://github.com/reggi/skywriter/issues/4

this fix FileCredentialStore and overhauls the config interaction layer into it's own class cleaning up some double reads of config, this removes the old `--auth-type` which didnt work as intended anyway and didnt make much sense... for --auth-store on login

now via `$SKYWRITER_SECRET` and `skywriter login --auth-store=file -y` it should be possible to login in github actions