### PR TITLE
chore: add Docker image publishing to GHCR on release

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+node_modules
+dist
+coverage
+test-results
+playwright-report
+.git
+e2e
+test
+.env
+*.md

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  packages: write
   id-token: write
 
 jobs:
@@ -52,3 +53,44 @@ jobs:
 
       - name: Publish to npm with provenance
         run: npm publish --provenance --access public --loglevel silly
+
+  docker:
+    needs: release-please
+    if: needs.release-please.outputs.release_created == 'true' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=raw,value=latest
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,9 @@
 !LICENSE
 !README.md
 !RAILWAY_DEPLOYMENT.md
+!.dockerignore
 !docker-compose.yml
+!Dockerfile
 !eslint.config.js
 !nixpacks.toml
 !package.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+# Stage 1: Build application
+FROM node:22-alpine AS builder
+RUN apk add --no-cache python3 make g++
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY . .
+RUN npm run build
+
+# Stage 2: Production dependencies only
+FROM node:22-alpine AS deps
+RUN apk add --no-cache python3 make g++
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci --omit=dev
+
+# Stage 3: Production image
+FROM node:22-alpine
+WORKDIR /app
+COPY package.json ./
+COPY --from=deps /app/node_modules ./node_modules
+COPY --from=builder /app/dist ./dist
+COPY --from=builder /app/migrations ./migrations
+COPY --from=builder /app/pages ./pages
+USER node
+EXPOSE 3000
+CMD ["sh", "-c", "npm run migrate:up && npm start"]


### PR DESCRIPTION
## Summary

Adds automatic Docker image publishing to GitHub Container Registry (ghcr.io) whenever a new version is released via release-please.

## Changes

- **`Dockerfile`** — Multi-stage build producing a minimal `node:22-alpine` production image
- **`.dockerignore`** — Excludes test files, node_modules, coverage, etc. from build context
- **`.github/workflows/release-please.yml`** — New `docker` job that builds and pushes to GHCR on release
- **`.gitignore`** — Allow `Dockerfile` and `.dockerignore` through the allowlist

## How it works

On release, the new `docker` job (runs in parallel with npm publish):
1. Logs into `ghcr.io` using the built-in `GITHUB_TOKEN`
2. Builds the multi-stage Dockerfile
3. Pushes with semver tags: `1.2.0`, `1.2`, `1`, `latest`

## Usage

```bash
docker run -p 3000:3000 -e DATABASE_URL=postgresql://... ghcr.io/reggi/skywriter:latest
```