### PR TITLE
fix: Docker deployment healthcheck and startup crashes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,12 +16,13 @@ RUN npm ci --omit=dev
 
 # Stage 3: Production image
 FROM node:22-alpine
+RUN apk add --no-cache git
 WORKDIR /app
 COPY package.json ./
 COPY --from=deps /app/node_modules ./node_modules
 COPY --from=builder /app/dist ./dist
 COPY --from=builder /app/migrations ./migrations
 COPY --from=builder /app/pages ./pages
-USER node
+RUN mkdir -p uploads .git-repos
 EXPOSE 3000
-CMD ["sh", "-c", "npm run migrate:up && npm start"]
+CMD ["node", "dist/cli/index.js", "host", "--migrate"]

--- a/railway.json
+++ b/railway.json
@@ -1,13 +1,12 @@
 {
   "$schema": "https://railway.com/railway.schema.json",
   "build": {
-    "builder": "RAILPACK",
-    "buildCommand": "npm run build"
+    "builder": "DOCKERFILE"
   },
   "deploy": {
-    "startCommand": "npm run migrate:up && npm start",
+    "startCommand": "node dist/cli/index.js host --migrate",
     "healthcheckPath": "/",
-    "healthcheckTimeout": 30,
+    "healthcheckTimeout": 120,
     "restartPolicyType": "ON_FAILURE",
     "restartPolicyMaxRetries": 10
   }

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -38,21 +38,33 @@ import {seedIfEmpty} from '../operations/seedIfEmpty.ts'
 
 export async function createApp(pool: Pool, options?: {seed?: boolean}) {
   if (options?.seed !== false) {
-    const client = await pool.connect()
     try {
-      await seedIfEmpty(client)
-    } finally {
-      client.release()
+      const client = await pool.connect()
+      try {
+        await seedIfEmpty(client)
+      } finally {
+        client.release()
+      }
+    } catch (err) {
+      console.error('Seed check failed (non-fatal):', err)
     }
   }
 
   const uploadsRaw = process.env.UPLOADS_PATH || 'uploads'
   const uploadsPath = isAbsolute(uploadsRaw) ? uploadsRaw : resolve(process.cwd(), uploadsRaw)
-  mkdirSync(uploadsPath, {recursive: true})
+  try {
+    mkdirSync(uploadsPath, {recursive: true})
+  } catch (err) {
+    console.error(`Warning: could not create uploads directory "${uploadsPath}":`, err)
+  }
 
   const gitReposRaw = process.env.GIT_REPOS_PATH || '.git-repos'
   const gitReposPath = isAbsolute(gitReposRaw) ? gitReposRaw : resolve(process.cwd(), gitReposRaw)
-  mkdirSync(gitReposPath, {recursive: true})
+  try {
+    mkdirSync(gitReposPath, {recursive: true})
+  } catch (err) {
+    console.error(`Warning: could not create git repos directory "${gitReposPath}":`, err)
+  }
 
   const app = new Hono<AppContext>()
 
@@ -112,6 +124,7 @@ export async function createApp(pool: Pool, options?: {seed?: boolean}) {
 
   // Error handler
   app.onError((err, c) => {
+    console.error('Server error:', err)
     if ('status' in err && err.status === 404) {
       return c.text('Not Found', 404)
     }


### PR DESCRIPTION
## Problem

The server failed to start in Docker/Railway — healthcheck at `/` returned "service unavailable" because the process crashed before `serve()` was called.

### Root causes

1. **`EACCES: permission denied, mkdir /volume/uploads`** — Dockerfile used `USER node` but Railway volumes are root-owned
2. **`git: not found`** — Alpine production image missing git binary
3. **`npm start` buffering stdout** — crash output was hidden from logs and healthcheck
4. **Unhandled `mkdirSync` / `seedIfEmpty` errors** — crashed the process before the server could start listening

## Changes

### Dockerfile
- Use `skywriter host --migrate` as CMD instead of `npm start` shell wrapper
- Add `git` to production image
- Remove `USER node` (incompatible with Railway volume mounts)

### railway.json
- Switch builder from `RAILPACK` to `DOCKERFILE`
- Use `node dist/cli/index.js host --migrate` as start command
- Increase healthcheck timeout from 30s to 120s

### Server startup (`src/server/index.ts`)
- Wrap `seedIfEmpty` in try/catch so DB issues do not crash the server
- Wrap `mkdirSync` calls in try/catch to handle permission errors gracefully
- Add `console.error` to Hono error handler for visibility

### CLI host command (`src/cli/utils/program.ts`)
- Default port to `PORT` env var (used by Railway/Docker)
- Support `MIGRATE` env var to control migrations at runtime
  - Precedence: env var > flag > default (false)
  - Warns if `--migrate` flag conflicts with `MIGRATE=false` env var