### PR TITLE
chore: fix docker image semver tags not being applied

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -16,6 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
+      major: ${{ steps.release.outputs.major }}
+      minor: ${{ steps.release.outputs.minor }}
+      patch: ${{ steps.release.outputs.patch }}
     steps:
       - uses: googleapis/release-please-action@v4
         id: release
@@ -80,9 +84,9 @@ jobs:
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
+            type=raw,value=${{ needs.release-please.outputs.major }}.${{ needs.release-please.outputs.minor }}.${{ needs.release-please.outputs.patch }},enable=${{ needs.release-please.outputs.release_created == 'true' }}
+            type=raw,value=${{ needs.release-please.outputs.major }}.${{ needs.release-please.outputs.minor }},enable=${{ needs.release-please.outputs.release_created == 'true' }}
+            type=raw,value=${{ needs.release-please.outputs.major }},enable=${{ needs.release-please.outputs.release_created == 'true' }}
             type=raw,value=latest
 
       - name: Build and push Docker image


### PR DESCRIPTION
The `docker/metadata-action` semver patterns require `github.ref` to be a tag (e.g. `refs/tags/v1.2.3`), but the workflow triggers on push to main so `github.ref` is `refs/heads/main`. This caused only the `latest` tag to be applied to Docker images.

**Fix:** Pass `major`/`minor`/`patch` outputs from `release-please` directly and use `type=raw` tags with explicit version values (e.g. `1.2.1`, `1.2`, `1`, `latest`).